### PR TITLE
fix: harden probes, releases, and container security

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*
+!go.mod
+!go.sum
+!main.go
+!config.yaml

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '02:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '02:15'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '02:30'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,89 +1,96 @@
 name: Build and Push Docker Image
 
 on:
-  # 1. 自动触发：当发布新 Release 时
-  release:
-    types: [published]
-
-  # 2. 手动触发：在 Actions 页面手动点击运行
+  push:
+    tags:
+      - 'v*'
+  schedule:
+    - cron: '17 3 * * 1'
   workflow_dispatch:
-    inputs:
-      version_tag:
-        description: 'Tag name (e.g. v1.0.0)'
-        required: true
-        default: 'dev'
-      make_latest:
-        description: 'Also tag as "latest"? (同时打上latest标签?)'
-        type: boolean
-        required: true
-        default: false
 
 permissions:
   contents: read
-  packages: write # 允许推送到 GHCR
+  packages: write
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  build-and-push:
-    name: Build and Push
+  build-scan-push:
+    name: Scan and publish multi-arch image
     runs-on: ubuntu-latest
-    
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+      - name: Build amd64 image for security gate
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          load: true
+          pull: true
+          no-cache: ${{ github.event_name == 'schedule' }}
+          tags: local/docker-mirror-monitor:scan
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          version: v0.72.0
+          scan-type: image
+          image-ref: local/docker-mirror-monitor:scan
+          scanners: vuln
+          severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+          ignore-unfixed: false
+          exit-code: '1'
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GPR_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      # --- 核心逻辑：标签生成规则 ---
-      - name: Extract Docker metadata
+      - name: Extract image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
-            ghcr.io/${{ github.repository_owner }}/docker-mirror-monitor
+            ghcr.io/${{ github.repository }}
             ${{ secrets.DOCKERHUB_USERNAME }}/docker-mirror-monitor
-          
           tags: |
-            # 规则 1: Release 事件 -> 自动生成语义化版本 (v1, v1.0, v1.0.0)
-            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
-            
-            # 规则 2: Release 事件 -> 强制打 latest
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
-            
-            # 规则 3: 手动触发 -> 使用输入的 version_tag (例如 v1.0.1-fix)
-            type=raw,value=${{ inputs.version_tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
-            
-            # 规则 4: 手动触发 -> 如果勾选了 make_latest，额外打 latest
-            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' && inputs.make_latest == true }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x
           push: true
+          pull: true
+          no-cache: ${{ github.event_name == 'schedule' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  go:
+    name: Go quality and vulnerability checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Test with race detector
+        run: go test -race ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
+
+      - name: Scan reachable Go vulnerabilities
+        run: govulncheck ./...
+
+  filesystem-security:
+    name: Trivy filesystem and configuration scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Scan repository with Trivy
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          version: v0.72.0
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,misconfig,secret
+          severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+          ignore-unfixed: false
+          exit-code: '1'

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,25 +1,29 @@
 name: Release Binaries
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version tag (e.g., v1.0.0)'
-        required: true
-        default: 'v1.0.0'
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   APP_NAME: docker-mirror-monitor
-  GO_VERSION: '1.24.12'
 
 jobs:
-  # Job 1: 手动触发时构建二进制文件并上传制品
   build-binaries:
-    name: Build Binaries
+    name: Build ${{ matrix.suffix }}
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'
-    
+    env:
+      VERSION: ${{ github.ref_name }}
+
     strategy:
+      fail-fast: false
       matrix:
         include:
           - goos: linux
@@ -30,7 +34,7 @@ jobs:
             suffix: linux-arm64
           - goos: linux
             goarch: arm
-            goarm: 7
+            goarm: '7'
             suffix: linux-armv7
           - goos: linux
             goarch: ppc64le
@@ -49,134 +53,74 @@ jobs:
             suffix: darwin-arm64
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
           cache-dependency-path: go.sum
 
-      - name: Get version from input
-        id: version
-        run: echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+      - name: Validate release tag
+        shell: bash
+        run: |
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            printf 'Invalid release tag: %s\n' "$VERSION" >&2
+            exit 1
+          fi
 
-      - name: Build binaries
+      - name: Build binary and checksum
+        shell: bash
         env:
-          CGO_ENABLED: 0
+          CGO_ENABLED: '0'
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           GOARM: ${{ matrix.goarm }}
+          SUFFIX: ${{ matrix.suffix }}
         run: |
-          VERSION=${{ steps.version.outputs.VERSION }}
-          BUILD_TIME=$(date +%Y%m%d%H%M%S)
-          LDFLAGS="-s -w -X main.Version=${VERSION} -X main.BuildTime=${BUILD_TIME}"
-          
-          OUTPUT_NAME="${{ env.APP_NAME }}-${VERSION}-${{ matrix.suffix }}"
-          go build -ldflags="${LDFLAGS}" -o "dist/${OUTPUT_NAME}" main.go
-          
-          # Create checksum
+          BUILD_TIME=$(date -u +%Y%m%d%H%M%S)
+          OUTPUT_NAME="${APP_NAME}-${VERSION}-${SUFFIX}"
+          mkdir -p dist
+          go build \
+            -trimpath \
+            -ldflags="-s -w -X main.Version=${VERSION} -X main.BuildTime=${BUILD_TIME}" \
+            -o "dist/${OUTPUT_NAME}" \
+            ./main.go
           cd dist
-          printf "# Version: %s\n" "${VERSION}" > ${OUTPUT_NAME}.sha256
-          sha256sum ${OUTPUT_NAME} >> ${OUTPUT_NAME}.sha256
+          sha256sum "$OUTPUT_NAME" > "${OUTPUT_NAME}.sha256"
 
-      - name: Upload binaries
-        uses: actions/upload-artifact@v4
+      - name: Upload binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binaries-${{ matrix.suffix }}
           path: |
-            dist/${{ env.APP_NAME }}-${{ steps.version.outputs.VERSION }}-${{ matrix.suffix }}
-            dist/${{ env.APP_NAME }}-${{ steps.version.outputs.VERSION }}-${{ matrix.suffix }}.sha256
+            dist/${{ env.APP_NAME }}-${{ env.VERSION }}-${{ matrix.suffix }}
+            dist/${{ env.APP_NAME }}-${{ env.VERSION }}-${{ matrix.suffix }}.sha256
+          if-no-files-found: error
+          retention-days: 7
 
-  # Job 2: 汇总制品并创建Release
   create-release:
-    name: Create Release
+    name: Create GitHub Release
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'
     needs: build-binaries
     permissions:
       contents: write
-    env:
-      VERSION: ${{ github.event.inputs.version }}
 
     steps:
       - name: Download binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           merge-multiple: true
 
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
+      - name: Create release
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
-          tag_name: ${{ env.VERSION }}
-          name: Release ${{ env.VERSION }}
-          body: |
-            <p><strong>Checksum note:</strong> Each <code>.sha256</code> file includes a first-line version header (e.g., <code># Version: v1.1.1</code>).</p>
-            <table>
-              <thead>
-                <tr>
-                  <th>Architecture</th>
-                  <th>OS</th>
-                  <th>Download</th>
-                  <th>SHA256</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td><img src="https://img.shields.io/badge/ARCH-amd64-2ea44f?style=flat" /></td>
-                  <td><img src="https://img.shields.io/badge/OS-Linux-fabd14?style=flat" /></td>
-                  <td><a href="https://github.com/${{ github.repository }}/releases/download/${{ env.VERSION }}/${{ env.APP_NAME }}-${{ env.VERSION }}-linux-amd64">Download</a></td>
-                  <td><a href="https://github.com/${{ github.repository }}/releases/download/${{ env.VERSION }}/${{ env.APP_NAME }}-${{ env.VERSION }}-linux-amd64.sha256">SHA256</a></td>
-                </tr>
-                <tr>
-                  <td><img src="https://img.shields.io/badge/ARCH-arm64-1f6feb?style=flat" /></td>
-                  <td><img src="https://img.shields.io/badge/OS-Linux-fabd14?style=flat" /></td>
-                  <td><a href="https://github.com/${{ github.repository }}/releases/download/${{ env.VERSION }}/${{ env.APP_NAME }}-${{ env.VERSION }}-linux-arm64">Download</a></td>
-                  <td><a href="https://github.com/${{ github.repository }}/releases/download/${{ env.VERSION }}/${{ env.APP_NAME }}-${{ env.VERSION }}-linux-arm64.sha256">SHA256</a></td>
-                </tr>
-                <tr>
-                  <td><img src="https://img.shields.io/badge/ARCH-armv7-1f6feb?style=flat" /></td>
-                  <td><img src="https://img.shields.io/badge/OS-Linux-fabd14?style=flat" /></td>
-                  <td><a href="https://github.com/${{ github.repository }}/releases/download/${{ env.VERSION }}/${{ env.APP_NAME }}-${{ env.VERSION }}-linux-armv7">Download</a></td>
-                  <td><a href="https://github.com/${{ github.repository }}/releases/download/${{ env.VERSION }}/${{ env.APP_NAME }}-${{ env.VERSION }}-linux-armv7.sha256">SHA256</a></td>
-                </tr>
-                <tr>
-                  <td><img src="https://img.shields.io/badge/ARCH-ppc64le-8b5cf6?style=flat" /></td>
-                  <td><img src="https://img.shields.io/badge/OS-Linux-fabd14?style=flat" /></td>
-                  <td><a href="https://github.com/${{ github.repository }}/releases/download/${{ env.VERSION }}/${{ env.APP_NAME }}-${{ env.VERSION }}-linux-ppc64le">Download</a></td>
-                  <td><a href="https://github.com/${{ github.repository }}/releases/download/${{ env.VERSION }}/${{ env.APP_NAME }}-${{ env.VERSION }}-linux-ppc64le.sha256">SHA256</a></td>
-                </tr>
-                <tr>
-                  <td><img src="https://img.shields.io/badge/ARCH-s390x-8b5cf6?style=flat" /></td>
-                  <td><img src="https://img.shields.io/badge/OS-Linux-fabd14?style=flat" /></td>
-                  <td><a href="https://github.com/${{ github.repository }}/releases/download/${{ env.VERSION }}/${{ env.APP_NAME }}-${{ env.VERSION }}-linux-s390x">Download</a></td>
-                  <td><a href="https://github.com/${{ github.repository }}/releases/download/${{ env.VERSION }}/${{ env.APP_NAME }}-${{ env.VERSION }}-linux-s390x.sha256">SHA256</a></td>
-                </tr>
-                <tr>
-                  <td><img src="https://img.shields.io/badge/ARCH-amd64-2ea44f?style=flat" /></td>
-                  <td><img src="https://img.shields.io/badge/OS-Windows-0078d4?style=flat" /></td>
-                  <td><a href="https://github.com/${{ github.repository }}/releases/download/${{ env.VERSION }}/${{ env.APP_NAME }}-${{ env.VERSION }}-windows-amd64.exe">Download</a></td>
-                  <td><a href="https://github.com/${{ github.repository }}/releases/download/${{ env.VERSION }}/${{ env.APP_NAME }}-${{ env.VERSION }}-windows-amd64.exe.sha256">SHA256</a></td>
-                </tr>
-                <tr>
-                  <td><img src="https://img.shields.io/badge/ARCH-amd64-2ea44f?style=flat" /></td>
-                  <td><img src="https://img.shields.io/badge/OS-macOS-000000?style=flat" /></td>
-                  <td><a href="https://github.com/${{ github.repository }}/releases/download/${{ env.VERSION }}/${{ env.APP_NAME }}-${{ env.VERSION }}-darwin-amd64">Download</a></td>
-                  <td><a href="https://github.com/${{ github.repository }}/releases/download/${{ env.VERSION }}/${{ env.APP_NAME }}-${{ env.VERSION }}-darwin-amd64.sha256">SHA256</a></td>
-                </tr>
-                <tr>
-                  <td><img src="https://img.shields.io/badge/ARCH-arm64-1f6feb?style=flat" /></td>
-                  <td><img src="https://img.shields.io/badge/OS-macOS-000000?style=flat" /></td>
-                  <td><a href="https://github.com/${{ github.repository }}/releases/download/${{ env.VERSION }}/${{ env.APP_NAME }}-${{ env.VERSION }}-darwin-arm64">Download</a></td>
-                  <td><a href="https://github.com/${{ github.repository }}/releases/download/${{ env.VERSION }}/${{ env.APP_NAME }}-${{ env.VERSION }}-darwin-arm64.sha256">SHA256</a></td>
-                </tr>
-              </tbody>
-            </table>
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          generate_release_notes: true
           files: dist/*
-          draft: false
-          prerelease: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          fail_on_unmatched_files: true
+          make_latest: true

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -123,4 +123,5 @@ jobs:
           generate_release_notes: true
           files: dist/*
           fail_on_unmatched_files: true
-          make_latest: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ !contains(github.ref_name, '-') }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,32 @@
-FROM --platform=$BUILDPLATFORM golang:1.24.12-alpine AS builder
-ARG TARGETPLATFORM
-ARG BUILDPLATFORM
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
-ARG APP_NAME=docker-mirror-monitor
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.24@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
 
-WORKDIR /app
-COPY go.mod go.sum* ./
-RUN go mod download 2>/dev/null || true
-COPY . .
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-s -w" -o ${APP_NAME} main.go
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY main.go ./
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} \
+    go build -trimpath -ldflags="-s -w" -o /out/docker-mirror-monitor ./main.go
 
-FROM alpine:3.18
-ENV TZ=Asia/Shanghai APP_NAME=docker-mirror-monitor
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+ENV TZ=Asia/Shanghai
 
 RUN apk --no-cache add ca-certificates tzdata && \
     addgroup -g 1000 -S appgroup && \
-    adduser -u 1000 -S appuser -G appgroup
-
-WORKDIR /app
-
-RUN mkdir -p /app/data && \
-    chown -R 1000:1000 /app/data && \
+    adduser -u 1000 -S appuser -G appgroup && \
+    mkdir -p /app/data && \
+    chown 1000:1000 /app/data && \
     chmod 755 /app/data
 
-COPY --from=builder --chown=1000:1000 --chmod=755 /app/${APP_NAME} /app/${APP_NAME}
-COPY --chown=1000:1000 --chmod=644 config.yaml* /app/data/
+WORKDIR /app
+COPY --from=builder --chown=1000:1000 --chmod=755 /out/docker-mirror-monitor /app/docker-mirror-monitor
+COPY --chown=1000:1000 --chmod=644 config.yaml /app/data/config.yaml
 
+USER 1000:1000
 EXPOSE 9080
-USER 1000
-
-CMD ["/app/docker-mirror-monitor", "-config", "/app/data/config.yaml"]
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD ["/app/docker-mirror-monitor", "healthcheck", "-config", "/app/data/config.yaml"]
+ENTRYPOINT ["/app/docker-mirror-monitor"]
+CMD ["-config", "/app/data/config.yaml"]

--- a/README.md
+++ b/README.md
@@ -671,8 +671,10 @@ git push origin v1.0.0
 # 3. GitHub Actions 自动执行：
 #    - 编译 8 个平台的二进制文件
 #    - 创建 GitHub Release 并上传文件
-#    - 构建并推送 Docker 多架构镜像到 GHCR
+#    - Trivy 扫描通过后，将多架构镜像推送到 GHCR 和 Docker Hub
 ```
+
+默认分支还会在每周一 03:17 UTC 重新构建并扫描 `latest` 镜像，以纳入 Alpine 软件包安全更新。Dependabot 每周检查 Go 模块、Docker 基础镜像 digest 和 GitHub Actions；依赖更新仍需通过 CI 后再合并。
 
 ### 生成的产物
 
@@ -680,14 +682,14 @@ git push origin v1.0.0
 
 | 文件名 | 平台 |
 |--------|------|
-| `docker-mirror-monitor-linux-amd64` | Linux x86_64 |
-| `docker-mirror-monitor-linux-arm64` | Linux ARM64 |
-| `docker-mirror-monitor-linux-armv7` | Linux ARMv7 |
-| `docker-mirror-monitor-linux-ppc64le` | Linux PowerPC 64 LE |
-| `docker-mirror-monitor-linux-s390x` | Linux IBM Z |
-| `docker-mirror-monitor-windows-amd64.exe` | Windows x64 |
-| `docker-mirror-monitor-darwin-amd64` | macOS Intel |
-| `docker-mirror-monitor-darwin-arm64` | macOS Apple Silicon |
+| `docker-mirror-monitor-<version>-linux-amd64` | Linux x86_64 |
+| `docker-mirror-monitor-<version>-linux-arm64` | Linux ARM64 |
+| `docker-mirror-monitor-<version>-linux-armv7` | Linux ARMv7 |
+| `docker-mirror-monitor-<version>-linux-ppc64le` | Linux PowerPC 64 LE |
+| `docker-mirror-monitor-<version>-linux-s390x` | Linux IBM Z |
+| `docker-mirror-monitor-<version>-windows-amd64.exe` | Windows x64 |
+| `docker-mirror-monitor-<version>-darwin-amd64` | macOS Intel |
+| `docker-mirror-monitor-<version>-darwin-arm64` | macOS Apple Silicon |
 
 每个文件附带 `.sha256` 校验文件。
 
@@ -695,23 +697,23 @@ git push origin v1.0.0
 
 ```bash
 # 拉取最新版本
-docker pull ghcr.io/your-username/your-repo:latest
+docker pull ghcr.io/okxlin/docker-mirror-monitor:latest
 
 # 拉取指定版本
-docker pull ghcr.io/your-username/your-repo:1.0.0
+docker pull ghcr.io/okxlin/docker-mirror-monitor:1.1.2
 
 # 支持架构：linux/amd64, linux/arm64, linux/arm/v7, linux/ppc64le, linux/s390x
 ```
 
 ### 自定义 Docker 镜像仓库
 
-如需推送到其他仓库（如 Docker Hub、阿里云），修改 `.github/workflows/release.yml`：
+如需推送到其他仓库（如阿里云），修改 `.github/workflows/build-docker-image.yml`：
 
 ```yaml
 # 添加额外的镜像仓库
 - name: Docker meta
   id: meta
-  uses: docker/metadata-action@v5
+  uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
   with:
     images: |
       ghcr.io/${{ github.repository }}
@@ -720,13 +722,13 @@ docker pull ghcr.io/your-username/your-repo:1.0.0
 
 # 添加对应的登录步骤
 - name: Login to Docker Hub
-  uses: docker/login-action@v3
+  uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
   with:
     username: ${{ secrets.DOCKERHUB_USERNAME }}
-    password: ${{ secrets.DOCKERHUB_TOKEN }}
+    password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
 - name: Login to Aliyun
-  uses: docker/login-action@v3
+  uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
   with:
     registry: registry.cn-hangzhou.aliyuncs.com
     username: ${{ secrets.ALIYUN_USERNAME }}
@@ -738,8 +740,8 @@ docker pull ghcr.io/your-username/your-repo:1.0.0
 | Secret 名称 | 说明 |
 |-------------|------|
 | `GITHUB_TOKEN` | 自动提供，无需配置 |
-| `DOCKERHUB_USERNAME` | Docker Hub 用户名（可选）|
-| `DOCKERHUB_TOKEN` | Docker Hub Access Token（可选）|
+| `DOCKERHUB_USERNAME` | Docker Hub 用户名 |
+| `DOCKERHUB_PASSWORD` | Docker Hub Access Token |
 | `ALIYUN_USERNAME` | 阿里云容器镜像服务用户名（可选）|
 | `ALIYUN_PASSWORD` | 阿里云容器镜像服务密码（可选）|
 

--- a/README.md
+++ b/README.md
@@ -60,11 +60,13 @@
 docker pull moelin/docker-mirror-monitor:latest
 
 # 运行（使用默认配置）
-docker run -d -p 9080:9080 docker-mirror-monitor:latest
+docker run -d -p 9080:9080 moelin/docker-mirror-monitor:latest
 
 # 运行（使用自定义配置）
+export DMM_API_TOKEN='replace-with-a-long-random-token'
 docker run -d \
   -p 9080:9080 \
+  -e DMM_API_TOKEN \
   -v $(pwd)/config.yaml:/app/data/config.yaml \
   -v $(pwd)/data:/app/data \
   moelin/docker-mirror-monitor:latest
@@ -77,6 +79,8 @@ services:
     image: moelin/docker-mirror-monitor:latest
     ports:
       - "9080:9080"
+    environment:
+      - DMM_API_TOKEN
     volumes:
       # 挂载配置文件
       - ./config.yaml:/app/data/config.yaml
@@ -483,7 +487,7 @@ groups:
 
 ### 环境要求
 
-- Go 1.22+
+- Go 1.26.5+
 - Docker 20.10+
 - Docker Buildx（多架构编译）
 
@@ -503,11 +507,11 @@ docker images | grep docker-mirror-monitor
 **Dockerfile 说明：**
 
 ```dockerfile
-# 构建阶段 - 使用 golang:1.24.12-alpine 作为编译环境
-FROM --platform=$BUILDPLATFORM golang:1.24.12-alpine AS builder
+# 构建阶段 - 固定 Go 1.26.5 / Alpine 3.24 多架构镜像
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.24@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 
-# 运行阶段 - 使用精简的 alpine 镜像
-FROM alpine:3.18
+# 运行阶段 - 固定 Alpine 3.24 多架构镜像
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 # 安装 ca-certificates（HTTPS支持）和 tzdata（时区支持）
 # 默认时区设置为 Asia/Shanghai
 ```
@@ -879,14 +883,13 @@ server {
 
 ## 配置热加载
 
-修改 `config.yaml` 后，无需重启服务，调用 API 即可热加载：
+修改 `config.yaml` 后，可调用 API 热加载。默认令牌为空，此时接口禁用；建议通过 `DMM_API_TOKEN` 环境变量设置令牌，避免把凭据提交到配置文件。
 
 ```bash
-# 热加载配置 (需要携带配置文件中定义的 api_token)
-curl -X POST "http://localhost:9080/api/reload?token=test-token-for-api-auth"
-
-# 或者使用 Header 方式：
-# curl -H "Authorization: test-token-for-api-auth" -X POST http://localhost:9080/api/reload
+# 仅接受 Bearer Header，不接受 URL 查询参数中的令牌
+curl -X POST \
+  -H "Authorization: Bearer ${DMM_API_TOKEN}" \
+  http://localhost:9080/api/reload
 
 # 成功响应
 {"success":true,"message":"配置重载成功，正在重新探测"}

--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@ server:
   debug: false              # 调试模式：false=只显示错误/启动信息，true=显示所有连接日志
   refresh_interval: 1800s    # 全局刷新间隔，<= 300s，系统将自动启用 WebSocket，> 300s，系统将自动启用 HTTP 定时拉取
   slow_threshold: 3000     # 响应时间超过3000ms视为缓慢
-  api_token: "test-token-for-api-auth"  # API访问令牌
+  api_token: ""              # 热加载令牌；建议通过 DMM_API_TOKEN 环境变量设置
   
   # 站点配置
   site:

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
 module docker-monitor
 
-go 1.24.12
-
-require gopkg.in/yaml.v3 v3.0.1
+go 1.26.5
 
 require (
-	github.com/gorilla/websocket v1.5.3 // indirect
-	golang.org/x/net v0.49.0 // indirect
+	github.com/gorilla/websocket v1.5.3
+	golang.org/x/net v0.56.0
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-golang.org/x/net v0.49.0 h1:eeHFmOGUTtaaPSGNmjBKpbng9MulQsJURQUAfUwY++o=
-golang.org/x/net v0.49.0/go.mod h1:/ysNB2EvaqvesRkuLAyjI1ycPZlQHM3q01F02UY/MV8=
+golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
+golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/main.go
+++ b/main.go
@@ -218,64 +218,69 @@ type StatusUpdate struct {
 	CheckedAt string        `json:"checked_at"`
 }
 
+type websocketClient struct {
+	hub  *Hub
+	conn *websocket.Conn
+	send chan *StatusUpdate
+}
+
 // Hub WebSocket连接管理
 type Hub struct {
-	clients    map[*websocket.Conn]bool
+	clients    map[*websocketClient]bool
 	broadcast  chan *StatusUpdate
-	register   chan *websocket.Conn
-	unregister chan *websocket.Conn
+	register   chan *websocketClient
+	unregister chan *websocketClient
 	mu         sync.RWMutex
 }
 
 func NewHub() *Hub {
 	return &Hub{
-		clients:    make(map[*websocket.Conn]bool),
+		clients:    make(map[*websocketClient]bool),
 		broadcast:  make(chan *StatusUpdate),
-		register:   make(chan *websocket.Conn),
-		unregister: make(chan *websocket.Conn),
+		register:   make(chan *websocketClient),
+		unregister: make(chan *websocketClient),
 	}
 }
 
 func (h *Hub) Run() {
 	for {
 		select {
-		case conn := <-h.register:
+		case client := <-h.register:
 			h.mu.Lock()
-			h.clients[conn] = true
+			h.clients[client] = true
 			clientCount := len(h.clients)
 			h.mu.Unlock()
 			logDebug("WebSocket客户端连接, 当前连接数: %d", clientCount)
 
-		case conn := <-h.unregister:
+		case client := <-h.unregister:
 			h.mu.Lock()
-			if _, ok := h.clients[conn]; ok {
-				delete(h.clients, conn)
-				conn.Close()
+			if _, ok := h.clients[client]; ok {
+				delete(h.clients, client)
+				close(client.send)
+				client.conn.Close()
 			}
 			clientCount := len(h.clients)
 			h.mu.Unlock()
 			logDebug("WebSocket客户端断开, 当前连接数: %d", clientCount)
 
 		case update := <-h.broadcast:
-			// 收集失败的连接，避免在遍历时修改map
-			var failedConns []*websocket.Conn
+			var slowClients []*websocketClient
 			h.mu.RLock()
-			for conn := range h.clients {
-				// 设置写入超时，防止慢客户端阻塞 Hub
-				conn.SetWriteDeadline(time.Now().Add(writeWait))
-				err := conn.WriteJSON(update)
-				if err != nil {
-					failedConns = append(failedConns, conn)
+			for client := range h.clients {
+				select {
+				case client.send <- update:
+				default:
+					slowClients = append(slowClients, client)
 				}
 			}
 			h.mu.RUnlock()
 
-			// 统一处理失败的连接
-			for _, conn := range failedConns {
+			for _, client := range slowClients {
 				h.mu.Lock()
-				if _, ok := h.clients[conn]; ok {
-					delete(h.clients, conn)
-					conn.Close()
+				if _, ok := h.clients[client]; ok {
+					delete(h.clients, client)
+					close(client.send)
+					client.conn.Close()
 				}
 				h.mu.Unlock()
 			}
@@ -287,6 +292,57 @@ func (h *Hub) Broadcast(update *StatusUpdate) {
 	select {
 	case h.broadcast <- update:
 	default:
+	}
+}
+
+func (c *websocketClient) writePump() {
+	ticker := time.NewTicker(pingPeriod)
+	defer func() {
+		ticker.Stop()
+		c.hub.unregister <- c
+		c.conn.Close()
+	}()
+
+	for {
+		select {
+		case update, ok := <-c.send:
+			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if !ok {
+				_ = c.conn.WriteMessage(websocket.CloseMessage, nil)
+				return
+			}
+			if err := c.conn.WriteJSON(update); err != nil {
+				return
+			}
+		case <-ticker.C:
+			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func (c *websocketClient) readPump() {
+	defer func() {
+		c.hub.unregister <- c
+		c.conn.Close()
+	}()
+
+	c.conn.SetReadLimit(maxMessageSize)
+	c.conn.SetReadDeadline(time.Now().Add(pongWait))
+	c.conn.SetPongHandler(func(string) error {
+		c.conn.SetReadDeadline(time.Now().Add(pongWait))
+		return nil
+	})
+
+	for {
+		if _, _, err := c.conn.ReadMessage(); err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+				logDebug("WebSocket连接异常关闭: %v", err)
+			}
+			return
+		}
 	}
 }
 
@@ -2986,6 +3042,32 @@ var upgrader = websocket.Upgrader{
 	},
 }
 
+func currentStatusUpdate(monitor *Monitor) *StatusUpdate {
+	return &StatusUpdate{
+		Groups:    monitor.GetGroupStatuses(),
+		CheckedAt: time.Now().Format("2006-01-02 15:04:05"),
+	}
+}
+
+func serveWebSocket(hub *Hub, monitor *Monitor, w http.ResponseWriter, r *http.Request) {
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		logDebug("WebSocket升级失败: %v", err)
+		return
+	}
+
+	client := &websocketClient{
+		hub:  hub,
+		conn: conn,
+		send: make(chan *StatusUpdate, 256),
+	}
+	client.send <- currentStatusUpdate(monitor)
+	hub.register <- client
+
+	go client.writePump()
+	client.readPump()
+}
+
 func reloadRequestAuthorized(r *http.Request, configuredToken string) bool {
 	if configuredToken == "" {
 		return false
@@ -3122,23 +3204,6 @@ func main() {
 	defer cancel()
 	go monitor.Start(ctx)
 
-	// WebSocket 心跳保活机制
-	// 每 30 秒发送一次空更新或特定心跳包，防止连接因闲置被断开
-	go func() {
-		ticker := time.NewTicker(30 * time.Second)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ticker.C:
-				// 发送一个轻量级的心跳数据，或者复用状态数据
-				// 这里为了简单，直接触发一次当前状态的广播（开销很小）
-				monitor.broadcastStatus()
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-
 	funcMap := template.FuncMap{
 		"tagClass":   makeTagClassFunc(config.Server.TagColors),
 		"formatTime": formatTime,
@@ -3205,52 +3270,7 @@ func main() {
 	})
 
 	http.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
-		conn, err := upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			logDebug("WebSocket升级失败: %v", err)
-			return
-		}
-
-		// 1. 设置读取限制 (防大包攻击)
-		conn.SetReadLimit(maxMessageSize)
-
-		// 2. 设置读取超时 (防僵尸连接)
-		conn.SetReadDeadline(time.Now().Add(pongWait))
-		conn.SetPongHandler(func(string) error {
-			conn.SetReadDeadline(time.Now().Add(pongWait))
-			return nil
-		})
-
-		hub.register <- conn
-
-		// 发送初始状态
-		groupStatuses := monitor.GetGroupStatuses()
-		update := &StatusUpdate{
-			Groups:    groupStatuses,
-			CheckedAt: time.Now().Format("2006-01-02 15:04:05"),
-		}
-
-		// 写入也要加超时
-		conn.SetWriteDeadline(time.Now().Add(writeWait))
-		if err := conn.WriteJSON(update); err != nil {
-			logDebug("WebSocket初始状态发送失败: %v", err)
-			conn.Close()
-			hub.unregister <- conn
-			return
-		}
-
-		// 循环读取 (处理 Close 消息和 Pong)
-		for {
-			_, _, err := conn.ReadMessage()
-			if err != nil {
-				if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
-					logDebug("WebSocket连接异常关闭: %v", err)
-				}
-				hub.unregister <- conn
-				conn.Close() // 确保关闭
-				break
-			}
-		}
+		serveWebSocket(hub, monitor, w, r)
 	})
 
 	// 安全的静态资源服务

--- a/main.go
+++ b/main.go
@@ -218,6 +218,8 @@ type StatusUpdate struct {
 	CheckedAt string        `json:"checked_at"`
 }
 
+const maxProbeConcurrency = 16
+
 type websocketClient struct {
 	hub  *Hub
 	conn *websocket.Conn
@@ -618,27 +620,41 @@ func (m *Monitor) ProbeAll() bool {
 	defer m.probeMu.Unlock()
 
 	config := m.GetConfig()
+	type probeJob struct {
+		groupID string
+		target  Target
+	}
+
+	workerCount := countTargets(config)
+	if workerCount > maxProbeConcurrency {
+		workerCount = maxProbeConcurrency
+	}
+	jobs := make(chan probeJob, workerCount)
 	var wg sync.WaitGroup
+	wg.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer wg.Done()
+			for job := range jobs {
+				time.Sleep(time.Duration(rand.Intn(2000)) * time.Millisecond)
+				result := m.Probe(job.target)
+
+				m.mu.Lock()
+				if m.results[job.groupID] == nil {
+					m.results[job.groupID] = make(map[string]*Result)
+				}
+				m.results[job.groupID][job.target.Name] = result
+				m.mu.Unlock()
+			}
+		}()
+	}
 
 	for _, group := range config.Groups {
 		for _, target := range group.Targets {
-			wg.Add(1)
-			go func(g Group, t Target) {
-				defer wg.Done()
-
-				time.Sleep(time.Duration(rand.Intn(2000)) * time.Millisecond)
-
-				result := m.Probe(t)
-
-				m.mu.Lock()
-				if m.results[g.ID] == nil {
-					m.results[g.ID] = make(map[string]*Result)
-				}
-				m.results[g.ID][t.Name] = result
-				m.mu.Unlock()
-			}(group, target)
+			jobs <- probeJob{groupID: group.ID, target: target}
 		}
 	}
+	close(jobs)
 
 	wg.Wait()
 

--- a/main.go
+++ b/main.go
@@ -293,6 +293,8 @@ type Monitor struct {
 	configPath string
 	results    map[string]map[string]*Result // groupID -> targetName -> Result
 	mu         sync.RWMutex
+	reloadMu   sync.Mutex
+	probeMu    sync.Mutex
 	hub        *Hub
 	httpClient *http.Client
 }
@@ -372,6 +374,9 @@ func createProxyTransport(proxyAddr string) *http.Transport {
 
 // ReloadConfig 热加载配置文件
 func (m *Monitor) ReloadConfig() error {
+	m.reloadMu.Lock()
+	defer m.reloadMu.Unlock()
+
 	newConfig, err := LoadAndValidateConfig(m.configPath)
 	if err != nil {
 		return fmt.Errorf("配置加载失败: %w", err)
@@ -414,13 +419,13 @@ func (m *Monitor) ReloadConfig() error {
 	}
 	m.results = newResults
 
-	log.Printf("配置热加载成功: %d 个分组, 共 %d 个监控目标", len(newConfig.Groups), m.getTotalTargets())
+	log.Printf("配置热加载成功: %d 个分组, 共 %d 个监控目标", len(newConfig.Groups), countTargets(newConfig))
 	return nil
 }
 
-func (m *Monitor) getTotalTargets() int {
+func countTargets(config *Config) int {
 	total := 0
-	for _, group := range m.config.Groups {
+	for _, group := range config.Groups {
 		total += len(group.Targets)
 	}
 	return total
@@ -531,10 +536,16 @@ func (m *Monitor) Probe(target Target) *Result {
 	return result
 }
 
-func (m *Monitor) ProbeAll() {
+func (m *Monitor) ProbeAll() bool {
+	if !m.probeMu.TryLock() {
+		return false
+	}
+	defer m.probeMu.Unlock()
+
+	config := m.GetConfig()
 	var wg sync.WaitGroup
 
-	for _, group := range m.config.Groups {
+	for _, group := range config.Groups {
 		for _, target := range group.Targets {
 			wg.Add(1)
 			go func(g Group, t Target) {
@@ -557,6 +568,7 @@ func (m *Monitor) ProbeAll() {
 	wg.Wait()
 
 	m.broadcastStatus()
+	return true
 }
 
 func (m *Monitor) broadcastStatus() {
@@ -616,7 +628,8 @@ func (m *Monitor) Start(ctx context.Context) {
 	rand.Seed(time.Now().UnixNano())
 
 	for {
-		baseInterval := m.config.Server.RefreshInterval
+		config := m.GetConfig()
+		baseInterval := config.Server.RefreshInterval
 		if baseInterval <= 0 {
 			baseInterval = 120 * time.Second
 		}
@@ -3256,7 +3269,8 @@ func main() {
 		}
 
 		// 如果配置了API密钥，必须匹配
-		if monitor.config.Server.APIToken != "" && token != monitor.config.Server.APIToken {
+		currentConfig := monitor.GetConfig()
+		if currentConfig.Server.APIToken != "" && token != currentConfig.Server.APIToken {
 			w.WriteHeader(http.StatusUnauthorized)
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"success": false,

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/subtle"
 	"crypto/tls"
 	"encoding/json"
@@ -350,14 +351,17 @@ func (c *websocketClient) readPump() {
 
 // Monitor 监控器
 type Monitor struct {
-	config     *Config
-	configPath string
-	results    map[string]map[string]*Result // groupID -> targetName -> Result
-	mu         sync.RWMutex
-	reloadMu   sync.Mutex
-	probeMu    sync.Mutex
-	hub        *Hub
-	httpClient *http.Client
+	config            *Config
+	configPath        string
+	results           map[string]map[string]*Result // groupID -> targetName -> Result
+	mu                sync.RWMutex
+	reloadMu          sync.Mutex
+	probeMu           sync.Mutex
+	probeQueueMu      sync.Mutex
+	probeQueueRunning bool
+	probeQueued       bool
+	hub               *Hub
+	httpClient        *http.Client
 }
 
 func NewMonitor(config *Config, configPath string, hub *Hub) *Monitor {
@@ -618,7 +622,39 @@ func (m *Monitor) ProbeAll() bool {
 		return false
 	}
 	defer m.probeMu.Unlock()
+	m.probeAll()
+	return true
+}
 
+func (m *Monitor) QueueProbe() {
+	m.probeQueueMu.Lock()
+	m.probeQueued = true
+	if m.probeQueueRunning {
+		m.probeQueueMu.Unlock()
+		return
+	}
+	m.probeQueueRunning = true
+	m.probeQueueMu.Unlock()
+
+	go func() {
+		for {
+			m.probeQueueMu.Lock()
+			if !m.probeQueued {
+				m.probeQueueRunning = false
+				m.probeQueueMu.Unlock()
+				return
+			}
+			m.probeQueued = false
+			m.probeQueueMu.Unlock()
+
+			m.probeMu.Lock()
+			m.probeAll()
+			m.probeMu.Unlock()
+		}
+	}()
+}
+
+func (m *Monitor) probeAll() {
 	config := m.GetConfig()
 	type probeJob struct {
 		groupID string
@@ -659,7 +695,6 @@ func (m *Monitor) ProbeAll() bool {
 	wg.Wait()
 
 	m.broadcastStatus()
-	return true
 }
 
 func (m *Monitor) broadcastStatus() {
@@ -3092,7 +3127,9 @@ func reloadRequestAuthorized(r *http.Request, configuredToken string) bool {
 	if !ok || !strings.EqualFold(scheme, "Bearer") || token == "" {
 		return false
 	}
-	return subtle.ConstantTimeCompare([]byte(token), []byte(configuredToken)) == 1
+	providedHash := sha256.Sum256([]byte(token))
+	configuredHash := sha256.Sum256([]byte(configuredToken))
+	return subtle.ConstantTimeCompare(providedHash[:], configuredHash[:]) == 1
 }
 
 func resolveConfigPath(configPath, configShort string) string {
@@ -3365,7 +3402,7 @@ func main() {
 		}
 
 		// 立即执行一次探测
-		go monitor.ProbeAll()
+		monitor.QueueProbe()
 
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(map[string]interface{}{

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/subtle"
 	"crypto/tls"
 	"encoding/json"
 	"flag"
@@ -22,6 +23,8 @@ import (
 	"golang.org/x/net/proxy"
 	"gopkg.in/yaml.v3"
 )
+
+const apiTokenEnv = "DMM_API_TOKEN"
 
 // TagColor 标签颜色配置
 type TagColor struct {
@@ -334,7 +337,7 @@ func createProxyTransport(proxyAddr string) *http.Transport {
 
 	proxyURL, err := url.Parse(proxyAddr)
 	if err != nil {
-		log.Printf("代理地址无效: %v", err)
+		log.Printf("代理地址无效")
 		return transport
 	}
 
@@ -363,13 +366,29 @@ func createProxyTransport(proxyAddr string) *http.Transport {
 	case "http", "https":
 		// HTTP/HTTPS代理
 		transport.Proxy = http.ProxyURL(proxyURL)
-		log.Printf("使用HTTP代理: %s", proxyAddr)
+		log.Printf("使用HTTP代理: %s", redactProxyAddress(proxyAddr))
 
 	default:
 		log.Printf("不支持的代理协议: %s", proxyURL.Scheme)
 	}
 
 	return transport
+}
+
+func redactProxyAddress(proxyAddr string) string {
+	if proxyAddr == "" {
+		return ""
+	}
+	proxyURL, err := url.Parse(proxyAddr)
+	if err != nil || proxyURL.Scheme == "" || proxyURL.Host == "" {
+		return "<invalid>"
+	}
+	proxyURL.User = nil
+	proxyURL.Path = ""
+	proxyURL.RawPath = ""
+	proxyURL.RawQuery = ""
+	proxyURL.Fragment = ""
+	return proxyURL.String()
 }
 
 // ReloadConfig 热加载配置文件
@@ -395,9 +414,9 @@ func (m *Monitor) ReloadConfig() error {
 
 		// 记录变化
 		if newConfig.Server.Proxy == "" {
-			log.Printf("代理已禁用 (原代理: %s)", oldProxy)
+			log.Printf("代理已禁用 (原代理: %s)", redactProxyAddress(oldProxy))
 		} else {
-			log.Printf("代理已更新: %s (原代理: %s)", newConfig.Server.Proxy, oldProxy)
+			log.Printf("代理已更新: %s (原代理: %s)", redactProxyAddress(newConfig.Server.Proxy), redactProxyAddress(oldProxy))
 		}
 	}
 
@@ -685,6 +704,9 @@ func LoadConfig(path string) (*Config, error) {
 	var config Config
 	if err := yaml.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("解析配置文件失败: %w", err)
+	}
+	if apiToken, ok := os.LookupEnv(apiTokenEnv); ok {
+		config.Server.APIToken = apiToken
 	}
 
 	if config.Server.Listen == "" {
@@ -2964,16 +2986,31 @@ var upgrader = websocket.Upgrader{
 	},
 }
 
+func reloadRequestAuthorized(r *http.Request, configuredToken string) bool {
+	if configuredToken == "" {
+		return false
+	}
+	scheme, token, ok := strings.Cut(r.Header.Get("Authorization"), " ")
+	if !ok || !strings.EqualFold(scheme, "Bearer") || token == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(token), []byte(configuredToken)) == 1
+}
+
+func resolveConfigPath(configPath, configShort string) string {
+	if configShort != "config.yaml" || configPath == "config.yaml" {
+		return configShort
+	}
+	return configPath
+}
+
 func main() {
 	configPath := flag.String("config", "config.yaml", "配置文件路径")
 	configShort := flag.String("c", "config.yaml", "配置文件路径")
 	flag.Parse()
 
 	// 使用 -c 参数优先，如果没有指定 -c 则使用 --config
-	actualConfigPath := *configPath
-	if *configShort != "config.yaml" || *configPath == "config.yaml" {
-		actualConfigPath = *configShort
-	}
+	actualConfigPath := resolveConfigPath(*configPath, *configShort)
 
 	// 检查是否有额外的命令行参数
 	args := flag.Args()
@@ -3079,7 +3116,7 @@ func main() {
 	hub := NewHub()
 	go hub.Run()
 
-	monitor := NewMonitor(config, *configPath, hub)
+	monitor := NewMonitor(config, actualConfigPath, hub)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -3254,36 +3291,29 @@ func main() {
 	http.HandleFunc("/api/reload", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
-		// 验证API密钥
-		token := r.Header.Get("Authorization")
-		if token == "" {
-			// 也尝试从查询参数获取
-			token = r.URL.Query().Get("token")
-		}
-
-		if token != "" {
-			// 移除 "Bearer " 前缀（如果存在）
-			if strings.HasPrefix(token, "Bearer ") {
-				token = strings.TrimPrefix(token, "Bearer ")
-			}
-		}
-
-		// 如果配置了API密钥，必须匹配
-		currentConfig := monitor.GetConfig()
-		if currentConfig.Server.APIToken != "" && token != currentConfig.Server.APIToken {
-			w.WriteHeader(http.StatusUnauthorized)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"success": false,
-				"error":   "未授权访问",
-			})
-			return
-		}
-
 		if r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"success": false,
 				"error":   "只支持 POST 请求",
+			})
+			return
+		}
+
+		currentConfig := monitor.GetConfig()
+		if currentConfig.Server.APIToken == "" {
+			w.WriteHeader(http.StatusForbidden)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"success": false,
+				"error":   "配置热加载未启用",
+			})
+			return
+		}
+		if !reloadRequestAuthorized(r, currentConfig.Server.APIToken) {
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"success": false,
+				"error":   "未授权访问",
 			})
 			return
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func writeMonitorConfig(t *testing.T, path, targetURL, token string) {
+	t.Helper()
+
+	config := fmt.Sprintf(`server:
+  listen: "127.0.0.1:0"
+  refresh_interval: 1s
+  slow_threshold: 100
+  api_token: %q
+groups:
+  - id: local
+    name: Local
+    targets:
+      - name: Health
+        url: %q
+        method: GET
+        timeout: 100ms
+`, token, targetURL)
+
+	if err := os.WriteFile(path, []byte(config), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+func TestProbeAllCoalescesConcurrentRuns(t *testing.T) {
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(requestStarted)
+		<-releaseRequest
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	writeMonitorConfig(t, configPath, target.URL, "test-token")
+	config, err := LoadAndValidateConfig(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	monitor := NewMonitor(config, configPath, NewHub())
+
+	firstResult := make(chan bool, 1)
+	go func() {
+		firstResult <- monitor.ProbeAll()
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("first probe did not start")
+	}
+
+	if monitor.ProbeAll() {
+		t.Fatal("second probe should be coalesced while the first is running")
+	}
+	close(releaseRequest)
+	if !<-firstResult {
+		t.Fatal("first probe should report that it ran")
+	}
+}
+
+func TestReloadConfigAndProbeAllAreRaceFree(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	writeMonitorConfig(t, configPath, target.URL, "test-token")
+
+	config, err := LoadAndValidateConfig(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	monitor := NewMonitor(config, configPath, NewHub())
+
+	start := make(chan struct{})
+	errors := make(chan error, 32)
+	var workers sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		workers.Add(2)
+		go func() {
+			defer workers.Done()
+			<-start
+			if err := monitor.ReloadConfig(); err != nil {
+				errors <- err
+			}
+		}()
+		go func() {
+			defer workers.Done()
+			<-start
+			monitor.ProbeAll()
+		}()
+	}
+
+	close(start)
+	workers.Wait()
+	close(errors)
+	for err := range errors {
+		t.Errorf("reload config: %v", err)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -11,6 +11,91 @@ import (
 	"time"
 )
 
+func TestReloadRequestAuthorization(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured string
+		header     string
+		query      string
+		want       bool
+	}{
+		{name: "disabled without configured token"},
+		{name: "rejects query token", configured: "secret", query: "secret"},
+		{name: "rejects raw authorization token", configured: "secret", header: "secret"},
+		{name: "rejects wrong bearer token", configured: "secret", header: "Bearer wrong"},
+		{name: "accepts bearer token", configured: "secret", header: "Bearer secret", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodPost, "/api/reload?token="+tt.query, nil)
+			if tt.header != "" {
+				request.Header.Set("Authorization", tt.header)
+			}
+			if got := reloadRequestAuthorized(request, tt.configured); got != tt.want {
+				t.Fatalf("reloadRequestAuthorized() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadConfigUsesEnvironmentAPIToken(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	writeMonitorConfig(t, configPath, target.URL, "file-token")
+	t.Setenv("DMM_API_TOKEN", "environment-token")
+
+	config, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if config.Server.APIToken != "environment-token" {
+		t.Fatalf("API token = %q, want environment override", config.Server.APIToken)
+	}
+}
+
+func TestRedactProxyAddress(t *testing.T) {
+	tests := map[string]string{
+		"":                                      "",
+		"https://proxy.example:8443":            "https://proxy.example:8443",
+		"https://user:password@proxy.example":   "https://proxy.example",
+		"socks5://user:password@127.0.0.1:1080": "socks5://127.0.0.1:1080",
+		"://invalid":                            "<invalid>",
+	}
+
+	for input, want := range tests {
+		if got := redactProxyAddress(input); got != want {
+			t.Errorf("redactProxyAddress(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestResolveConfigPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		longPath  string
+		shortPath string
+		want      string
+	}{
+		{name: "defaults", longPath: "config.yaml", shortPath: "config.yaml", want: "config.yaml"},
+		{name: "long flag", longPath: "long.yaml", shortPath: "config.yaml", want: "long.yaml"},
+		{name: "short flag", longPath: "config.yaml", shortPath: "short.yaml", want: "short.yaml"},
+		{name: "short flag wins", longPath: "long.yaml", shortPath: "short.yaml", want: "short.yaml"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveConfigPath(tt.longPath, tt.shortPath); got != tt.want {
+				t.Fatalf("resolveConfigPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func writeMonitorConfig(t *testing.T, path, targetURL, token string) {
 	t.Helper()
 

--- a/main_test.go
+++ b/main_test.go
@@ -6,9 +6,12 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/gorilla/websocket"
 )
 
 func TestReloadRequestAuthorization(t *testing.T) {
@@ -196,5 +199,54 @@ func TestReloadConfigAndProbeAllAreRaceFree(t *testing.T) {
 	close(errors)
 	for err := range errors {
 		t.Errorf("reload config: %v", err)
+	}
+}
+
+func TestServeWebSocketSerializesInitialStateAndBroadcasts(t *testing.T) {
+	hub := NewHub()
+	go hub.Run()
+
+	monitor := NewMonitor(&Config{}, "", hub)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serveWebSocket(hub, monitor, w, r)
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + server.URL[len("http"):]
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer conn.Close()
+
+	if err := conn.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	var update StatusUpdate
+	if err := conn.ReadJSON(&update); err != nil {
+		t.Fatalf("read initial websocket update: %v", err)
+	}
+	if update.CheckedAt == "" {
+		t.Fatal("initial websocket update must include checked_at")
+	}
+
+	stopBroadcasts := make(chan struct{})
+	defer close(stopBroadcasts)
+	go func() {
+		for i := 0; ; i++ {
+			select {
+			case <-stopBroadcasts:
+				return
+			default:
+				hub.Broadcast(&StatusUpdate{CheckedAt: fmt.Sprintf("broadcast-%d", i)})
+			}
+		}
+	}()
+
+	if err := conn.ReadJSON(&update); err != nil {
+		t.Fatalf("read broadcast websocket update: %v", err)
+	}
+	if !strings.HasPrefix(update.CheckedAt, "broadcast-") {
+		t.Fatalf("broadcast checked_at = %q", update.CheckedAt)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -199,6 +200,65 @@ func TestReloadConfigAndProbeAllAreRaceFree(t *testing.T) {
 	close(errors)
 	for err := range errors {
 		t.Errorf("reload config: %v", err)
+	}
+}
+
+func TestProbeAllLimitsConcurrentRequests(t *testing.T) {
+	const concurrencyLimit = 16
+
+	var current atomic.Int32
+	var maximum atomic.Int32
+	releaseRequests := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(releaseRequests)
+		}
+	}()
+
+	targetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		active := current.Add(1)
+		defer current.Add(-1)
+		for {
+			observed := maximum.Load()
+			if active <= observed || maximum.CompareAndSwap(observed, active) {
+				break
+			}
+		}
+		<-releaseRequests
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer targetServer.Close()
+
+	targets := make([]Target, 64)
+	for i := range targets {
+		targets[i] = Target{
+			Name:    fmt.Sprintf("target-%d", i),
+			URL:     fmt.Sprintf("%s?id=%d", targetServer.URL, i),
+			Method:  http.MethodGet,
+			Timeout: 10 * time.Second,
+		}
+	}
+	config := &Config{Groups: []Group{{ID: "test", Name: "Test", Targets: targets}}}
+	monitor := NewMonitor(config, "", NewHub())
+
+	probeResult := make(chan bool, 1)
+	go func() {
+		probeResult <- monitor.ProbeAll()
+	}()
+
+	deadline := time.Now().Add(2500 * time.Millisecond)
+	for time.Now().Before(deadline) && maximum.Load() <= concurrencyLimit {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	close(releaseRequests)
+	released = true
+	if !<-probeResult {
+		t.Fatal("probe run should complete")
+	}
+	if got := maximum.Load(); got > concurrencyLimit {
+		t.Fatalf("maximum concurrent probes = %d, want <= %d", got, concurrencyLimit)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -203,6 +203,59 @@ func TestReloadConfigAndProbeAllAreRaceFree(t *testing.T) {
 	}
 }
 
+func TestQueueProbeRunsAfterActiveProbeForReloadedConfig(t *testing.T) {
+	oldRequestStarted := make(chan struct{})
+	releaseOldRequest := make(chan struct{})
+	oldTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(oldRequestStarted)
+		<-releaseOldRequest
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer oldTarget.Close()
+
+	newRequestStarted := make(chan struct{})
+	newTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(newRequestStarted)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer newTarget.Close()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	writeMonitorConfig(t, configPath, oldTarget.URL, "test-token")
+	config, err := LoadAndValidateConfig(configPath)
+	if err != nil {
+		t.Fatalf("load initial config: %v", err)
+	}
+	monitor := NewMonitor(config, configPath, NewHub())
+
+	activeProbe := make(chan bool, 1)
+	go func() {
+		activeProbe <- monitor.ProbeAll()
+	}()
+
+	select {
+	case <-oldRequestStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("initial probe did not start")
+	}
+
+	writeMonitorConfig(t, configPath, newTarget.URL, "test-token")
+	if err := monitor.ReloadConfig(); err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	monitor.QueueProbe()
+	close(releaseOldRequest)
+
+	if !<-activeProbe {
+		t.Fatal("active probe should complete")
+	}
+	select {
+	case <-newRequestStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("queued probe did not use the reloaded config")
+	}
+}
+
 func TestProbeAllLimitsConcurrentRequests(t *testing.T) {
 	const concurrencyLimit = 16
 


### PR DESCRIPTION
## Summary

- serialize config reloads, coalesce reload probes, bound probe concurrency, and enforce one WebSocket writer per connection
- require Bearer authentication for reloads, support `DMM_API_TOKEN`, and redact proxy credentials from logs
- upgrade to Go 1.26.5, x/net 0.56.0, and Alpine 3.24 with pinned multi-arch image digests
- add race/vet/govulncheck/Trivy CI, weekly secure image rebuilds, Dependabot, and tag-driven binary/image releases

## Security evidence

The published v1.1.1 image had 1 Critical, 16 High, 12 Medium, 1 Low, and 1 Unknown finding on every architecture. The rebuilt v1.1.2 candidate reports 0 findings for both Alpine packages and the Go binary.

## Verification

- `go test -race ./...`
- `go vet ./...`
- `govulncheck ./...`
- `actionlint .github/workflows/*.yml`
- `trivy fs --scanners vuln,misconfig,secret ...`
- local Docker build, non-root runtime, `/healthz`, and Trivy image scan
- five-platform Docker build: amd64, arm64, arm/v7, ppc64le, s390x
- eight-platform release binary cross-build with SHA-256 verification
