### PR TITLE
fix: restore GHCR publishing for legacy package

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -7,6 +7,16 @@ on:
   schedule:
     - cron: '17 3 * * 1'
   workflow_dispatch:
+    inputs:
+      version_tag:
+        description: Optional image tag, for example 1.1.2
+        required: false
+        type: string
+      make_latest:
+        description: Also publish the latest tag
+        required: true
+        default: true
+        type: boolean
 
 permissions:
   contents: read
@@ -60,7 +70,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ github.token }}
+          password: ${{ secrets.GPR_TOKEN || github.token }}
 
       - name: Log in to Docker Hub
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -79,7 +89,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest
+            type=raw,value=${{ inputs.version_tag }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.version_tag != '' }}
+            type=raw,value=latest,enable=${{ github.event_name != 'workflow_dispatch' || inputs.make_latest }}
 
       - name: Build and push multi-arch image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0


### PR DESCRIPTION
## Summary

- prefer the existing `GPR_TOKEN` only for the legacy GHCR package ACL, while retaining `github.token` as the fallback for repository-linked packages
- add structured workflow-dispatch inputs so the already-published v1.1.2 application content can be republished without moving the release tag

## Evidence

The v1.1.2 tag workflow built and scanned successfully, then GHCR rejected the repository token with 403 while checking an existing package blob. Historical successful runs used the existing `GPR_TOKEN` for this package.

## Verification

- `actionlint .github/workflows/*.yml`
- no user-controlled input is interpolated into a shell command
