### PR TITLE
ci: preserve v prefix in image tags

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       version_tag:
-        description: Optional image tag, for example 1.1.2
+        description: Optional image tag, for example v1.1.3
         required: false
         type: string
       make_latest:
@@ -88,9 +88,9 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
             type=raw,value=${{ inputs.version_tag }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.version_tag != '' }}
             type=raw,value=latest,enable=${{ github.event_name != 'workflow_dispatch' || inputs.make_latest }}
 


### PR DESCRIPTION
## Summary
- preserve the historical `v` prefix for semantic-version image tags
- keep moving aliases consistent as `v1.1` and `v1`
- update the manual-dispatch example to `v1.1.3`

## Verification
- `actionlint .github/workflows/build-docker-image.yml`
- `go test ./...`
- `go vet ./...`
- tag rule assertions for `v{{version}}`, `v{{major}}.{{minor}}`, and `v{{major}}`