### PR TITLE
ci: update vulnerability scanners

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          version: v0.72.0
+          version: v0.74.0
           scan-type: image
           image-ref: local/docker-mirror-monitor:scan
           scanners: vuln

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: go vet ./...
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
 
       - name: Scan reachable Go vulnerabilities
         run: govulncheck ./...
@@ -54,7 +54,7 @@ jobs:
       - name: Scan repository with Trivy
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          version: v0.72.0
+          version: v0.74.0
           scan-type: fs
           scan-ref: .
           scanners: vuln,misconfig,secret


### PR DESCRIPTION
## Summary

- update govulncheck from v1.6.0 to v1.7.0
- update the Trivy CLI used by repository and image scans from v0.72.0 to v0.74.0
- keep the pinned trivy-action digest and all existing severity/exit-code gates unchanged

## Verification

- `actionlint`
- `go test -race ./...`
- `go vet ./...`
- `go mod verify`
- `govulncheck v1.7.0 ./...` — no vulnerabilities
- Trivy v0.74.0 filesystem/config/secret scan — no findings
- Trivy v0.74.0 scan of the current amd64 image — 0 Alpine and 0 Go binary vulnerabilities

## Sources

- https://proxy.golang.org/golang.org/x/vuln/@v/v1.7.0.info
- https://github.com/aquasecurity/trivy/releases/tag/v0.74.0
- https://github.com/aquasecurity/trivy-action/releases/tag/v0.36.0