### PR TITLE
chore: refresh frontend assets and build metadata

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -41,6 +41,26 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
+      - name: Prepare build metadata
+        id: build_meta
+        shell: bash
+        env:
+          REQUESTED_VERSION: ${{ inputs.version_tag }}
+        run: |
+          if [[ -n "$REQUESTED_VERSION" ]]; then
+            version="$REQUESTED_VERSION"
+          elif [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            version="$GITHUB_REF_NAME"
+          else
+            version="${GITHUB_SHA::12}"
+          fi
+          if [[ ! "$version" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+            printf 'Invalid build version: %s\n' "$version" >&2
+            exit 1
+          fi
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+          printf 'build_time=%s\n' "$(date -u +%Y%m%d%H%M%S)" >> "$GITHUB_OUTPUT"
+
       - name: Build amd64 image for security gate
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
@@ -51,6 +71,9 @@ jobs:
           pull: true
           no-cache: ${{ github.event_name == 'schedule' }}
           tags: local/docker-mirror-monitor:scan
+          build-args: |
+            VERSION=${{ steps.build_meta.outputs.version }}
+            BUILD_TIME=${{ steps.build_meta.outputs.build_time }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -105,5 +128,8 @@ jobs:
           no-cache: ${{ github.event_name == 'schedule' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.build_meta.outputs.version }}
+            BUILD_TIME=${{ steps.build_meta.outputs.build_time }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,15 @@ FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine3.24@sha256:3889b425f035be855
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT
+ARG VERSION=dev
+ARG BUILD_TIME=unknown
 
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY main.go ./
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} \
-    go build -trimpath -ldflags="-s -w" -o /out/docker-mirror-monitor ./main.go
+    go build -trimpath -ldflags="-s -w -X main.Version=${VERSION} -X main.BuildTime=${BUILD_TIME}" -o /out/docker-mirror-monitor ./main.go
 
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 ENV TZ=Asia/Shanghai

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 # Docker Mirror Monitor - Makefile
 APP_NAME := docker-mirror-monitor
-VERSION := 1.0.0
-BUILD_TIME := $(shell date +%Y%m%d%H%M%S)
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || printf 'dev')
+BUILD_TIME ?= $(shell date -u +%Y%m%d%H%M%S)
 DOCKER_IMAGE := docker-mirror-monitor
+.DEFAULT_GOAL := help
 
 # Supported platforms
 PLATFORMS := linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x
@@ -10,7 +11,9 @@ PLATFORMS := linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x
 # Go build flags
 LDFLAGS := -ldflags="-s -w -X main.Version=$(VERSION) -X main.BuildTime=$(BUILD_TIME)"
 
-.PHONY: all build clean docker docker-multi run help
+.PHONY: all help build build-all build-linux-amd64 build-linux-arm64 build-linux-armv7 build-linux-ppc64le build-linux-s390x build-windows build-darwin build-darwin-arm64 docker docker-multi docker-local run clean
+
+all: build
 
 help:
 	@echo "Usage:"
@@ -54,11 +57,13 @@ build-darwin-arm64:
 
 # Build Docker image (single arch)
 docker:
-	docker build -t $(DOCKER_IMAGE):$(VERSION) -t $(DOCKER_IMAGE):latest .
+	docker build --build-arg VERSION="$(VERSION)" --build-arg BUILD_TIME="$(BUILD_TIME)" -t $(DOCKER_IMAGE):$(VERSION) -t $(DOCKER_IMAGE):latest .
 
 # Build multi-arch Docker image and push
 docker-multi:
 	docker buildx build --platform $(PLATFORMS) \
+		--build-arg VERSION="$(VERSION)" \
+		--build-arg BUILD_TIME="$(BUILD_TIME)" \
 		-t $(DOCKER_IMAGE):$(VERSION) \
 		-t $(DOCKER_IMAGE):latest \
 		--push .
@@ -66,6 +71,8 @@ docker-multi:
 # Build multi-arch and load locally (only works for single arch at a time)
 docker-local:
 	docker buildx build --platform linux/amd64 \
+		--build-arg VERSION="$(VERSION)" \
+		--build-arg BUILD_TIME="$(BUILD_TIME)" \
 		-t $(DOCKER_IMAGE):$(VERSION) \
 		-t $(DOCKER_IMAGE):latest \
 		--load .

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ server:
   # 站点配置
   site:
     logo: "容器镜像监控"        # Header左侧Logo文字
-    logo_icon: "fab fa-docker"  # Logo图标（需带 fab/fas 前缀）
+    logo_icon: "fa-brands fa-docker"  # Logo图标（品牌图标使用 fa-brands）
     title: "容器镜像加速器监控"  # 页面主标题
     description: "实时监控多种容器镜像源的加速器状态"  # 页面描述
     browser_title: "容器镜像监控"  # 浏览器标签页标题
@@ -176,7 +176,7 @@ server:
     enabled: false              # 是否启用
     text: "限时优惠！"          # 公告文字
     url: ""                     # 点击跳转链接
-    icon: "fas fa-tag"          # 增加 fas 前缀
+    icon: "fa-classic fa-solid fa-tag" # 实心图标使用 fa-classic fa-solid
     color: "#ff6b6b"            # 文字颜色
     bg_color: "rgba(255,107,107,0.1)"  # 背景颜色
   
@@ -308,7 +308,7 @@ proxy: "socks5://username:password@127.0.0.1:1080"
 | 配置项 | 类型 | 说明 | 默认值 |
 |--------|------|------|--------|
 | `logo` | string | Header左侧Logo文字 | `"容器镜像监控"` |
-| `logo_icon` | string | Logo图标（Font Awesome） | `"fa-docker"` |
+| `logo_icon` | string | Logo图标（Font Awesome） | `"fa-brands fa-docker"` |
 | `title` | string | 页面主标题 | `"容器镜像加速器监控"` |
 | `description` | string | 页面描述 | `"实时监控多种容器镜像源..."` |
 | `browser_title` | string | 浏览器标签页标题 | `"容器镜像监控"` |
@@ -317,7 +317,7 @@ proxy: "socks5://username:password@127.0.0.1:1080"
 ```yaml
 site:
   logo: "我的监控"
-  logo_icon: "fa-server"
+  logo_icon: "fa-classic fa-solid fa-server"
   title: "Docker镜像源监控"
   description: "自建镜像监控系统"
   browser_title: "镜像监控"
@@ -331,7 +331,7 @@ site:
 | `enabled` | bool | 是否启用 | `false` |
 | `text` | string | 公告文字 | `"站点公告"` |
 | `url` | string | 点击跳转链接 | `""` |
-| `icon` | string | Font Awesome图标 | `"fas fa-bullhorn"` |
+| `icon` | string | Font Awesome图标 | `"fa-classic fa-solid fa-bullhorn"` |
 | `color` | string | 文字颜色 | `"#ff6b6b"` |
 | `bg_color` | string | 背景颜色 | `"rgba(255,107,107,0.1)"` |
 
@@ -340,7 +340,7 @@ site_notice:
   enabled: true
   text: "🎉 限时优惠活动"
   url: "https://example.com/promo"
-  icon: "fas fa-bullhorn"
+  icon: "fa-classic fa-solid fa-bullhorn"
   color: "#ff6b6b"
   bg_color: "rgba(255,107,107,0.12)"
 ```
@@ -548,7 +548,7 @@ make docker-multi
 docker buildx build \
   --platform linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x \
   -t your-registry/container-mirror-monitor:latest \
-  -t your-registry/container-mirror-monitor:1.0.0 \
+  -t your-registry/container-mirror-monitor:v1.1.5 \
   --push .
 
 # 方式三：仅构建 amd64 并加载到本地
@@ -598,8 +598,14 @@ docker buildx build --platform linux/amd64,linux/arm64 \
 # 编译当前平台
 make build
 
+# 查看版本与构建时间
+./docker-mirror-monitor version
+
 # 编译所有平台（输出到 dist/ 目录）
 make build-all
+
+# 需要显式指定版本时可覆盖自动推导值
+make build VERSION=v1.1.5
 
 # 手动编译指定平台
 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o docker-mirror-monitor main.go
@@ -626,31 +632,43 @@ CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w" -o docker-mirro
 
 ## GitHub Actions CI/CD
 
-项目提供两个 GitHub Actions workflow，实现自动化构建和发布。
+项目提供三个 GitHub Actions workflow，实现自动化检查、构建和发布。
 
 ### Workflow 文件
 
 ```
 .github/workflows/
-├── build-docker-image.yml  # 发布版本时构建并推送 Docker 镜像
-└── release-binaries.yml    # 手动触发或发布版本时编译二进制文件
+├── ci.yml                  # PR 与 main 分支的质量、安全检查
+├── build-docker-image.yml  # 发布、定时或手动构建并推送 Docker 镜像
+└── release-binaries.yml    # 发布版本时编译二进制文件并创建 Release
 ```
 
 ### build-docker-image.yml - 构建 Docker 镜像
 
 **触发条件：**
 - 推送以 `v` 开头的 Tag（如 `v1.0.0`）
+- 每周一定时重建 `latest`，纳入基础镜像的软件包安全更新
 - 手动触发（workflow_dispatch）
 
 **执行内容：**
-1. **构建 Docker 镜像** - 支持多架构（linux/amd64, linux/arm64, linux/arm/v7, linux/ppc64le, linux/s390x）
-2. **推送镜像** - 推送到 GitHub Container Registry (GHCR)
+1. **安全扫描** - 先构建 amd64 镜像并通过 Trivy 漏洞门禁
+2. **构建 Docker 镜像** - 支持多架构（linux/amd64, linux/arm64, linux/arm/v7, linux/ppc64le, linux/s390x）
+3. **推送镜像** - 同步推送到 GitHub Container Registry (GHCR) 和 Docker Hub
+
+### ci.yml - 代码质量与安全检查
+
+**触发条件：**
+- 向 `main` 提交 Pull Request
+- 推送到 `main`
+
+**执行内容：**
+1. **Go 质量检查** - race test、vet、govulncheck
+2. **仓库安全扫描** - Trivy 文件系统、配置和敏感信息扫描
 
 ### release-binaries.yml - 编译二进制文件
 
 **触发条件：**
 - 推送以 `v` 开头的 Tag（如 `v1.0.0`）
-- 手动触发（workflow_dispatch）
 
 **执行内容：**
 1. **编译二进制文件** - 8 个平台，生成 SHA256 校验文件
@@ -700,7 +718,7 @@ git push origin v1.0.0
 docker pull ghcr.io/okxlin/docker-mirror-monitor:latest
 
 # 拉取指定版本
-docker pull ghcr.io/okxlin/docker-mirror-monitor:1.1.2
+docker pull ghcr.io/okxlin/docker-mirror-monitor:v1.1.5
 
 # 支持架构：linux/amd64, linux/arm64, linux/arm/v7, linux/ppc64le, linux/s390x
 ```
@@ -856,13 +874,13 @@ server {
 
 1.  **Font Awesome 图标**（推荐）：
     ```yaml
-    logo_icon: "fab fa-docker"  # 品牌图标
-    logo_icon: "fas fa-server"  # 实心图标
+    logo_icon: "fa-brands fa-docker"          # 品牌图标
+    logo_icon: "fa-classic fa-solid fa-server" # 实心图标
     ```
 
-> **注意**：本项目使用 Font Awesome 5，请务必添加正确的风格前缀：
-> * **品牌图标** (GitHub, Docker, 微信)：使用 **`fab`** (如 `fab fa-weixin`)
-> * **常规图标** (Home, Server, Link)：使用 **`fas`** (如 `fas fa-link`)
+> **注意**：本项目使用 Font Awesome 7，请添加正确的图标族和样式类：
+> * **品牌图标** (GitHub, Docker, 微信)：使用 **`fa-brands`** (如 `fa-brands fa-weixin`)
+> * **常规图标** (Home, Server, Link)：使用 **`fa-classic fa-solid`** (如 `fa-classic fa-solid fa-link`)
 
 2.  **网络图片**：
     ```yaml

--- a/config.yaml
+++ b/config.yaml
@@ -8,16 +8,16 @@ server:
   # 站点配置
   site:
     logo: "容器镜像监控"            # Header左侧Logo文字
-    logo_icon: "fab fa-docker"          # Logo图标（支持Font Awesome类名或图片路径）
+    logo_icon: "fa-brands fa-docker"    # Logo图标（支持Font Awesome类名或图片路径）
     # Logo图标支持多种格式：
-    # 1. Font Awesome图标: "fab fa-docker", "fas fa-cube", "fas fa-server" 等
+    # 1. Font Awesome图标: "fa-brands fa-docker", "fa-classic fa-solid fa-cube", "fa-classic fa-solid fa-server" 等
     # 2. 本地图片: "/custom/logo.png", "/custom/my-icon.svg" (需放在 ./data/public/ 目录下)
     # 3. 网络图片: "https://example.com/logo.png"
     # 4. Base64图片: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
     # 
-    # 提示：Font Awesome 5 图标请注意前缀：
-    # * 品牌图标（如 Docker, GitHub, 微信）：使用 **fab** (例如 fab fa-weixin)
-    # * 常规图标（如 首页, 设置）：使用 **fas** (例如 fas fa-home)
+    # 提示：Font Awesome 7 图标请注意图标族和样式类：
+    # * 品牌图标（如 Docker, GitHub, 微信）：使用 **fa-brands** (例如 fa-brands fa-weixin)
+    # * 常规图标（如 首页, 设置）：使用 **fa-classic fa-solid** (例如 fa-classic fa-solid fa-home)
     title: "容器镜像加速器监控"      # 页面主标题
     description: "实时监控多种容器镜像源的加速器状态，帮助开发者选择最佳的镜像源"  # 页面描述
     browser_title: "容器镜像监控"   # 浏览器标签页标题
@@ -65,14 +65,14 @@ server:
     #enabled: false              # 是否启用顶部公告
     #text: "站点公告"             # 公告文字
     #url: ""                     # 点击跳转链接
-    #icon: "fas fa-bullhorn"         # Font Awesome图标（可选，建议用fa-bullhorn或fa-bell）
+    #icon: "fa-classic fa-solid fa-bullhorn" # Font Awesome图标（可选，建议用fa-bullhorn或fa-bell）
     #color: "#ff6b6b"            # 文字颜色
     #bg_color: "rgba(255,107,107,0.1)"  # 背景颜色
     # 示例配置:
     enabled: true
     text: "1Panel & Halo 限时优惠 🎉"
     url: "https://www.lxware.cn?code=sssvip"
-    icon: "fas fa-gift"
+    icon: "fa-classic fa-solid fa-gift"
     color: "#ff6b6b"
     bg_color: "rgba(255,107,107,0.1)"
 
@@ -191,11 +191,11 @@ server:
       # 捐赠方式列表
       items: []
         # - name: "微信支付"
-        #   icon: "fab fa-weixin"     # 品牌图标使用 fab
+        #   icon: "fa-brands fa-weixin" # 品牌图标使用 fa-brands
         #   qrcode: ""                # 二维码图片URL或base64
         #   color: "#07c160"
         # - name: "支付宝"
-        #   icon: "fab fa-alipay"     # 支付宝也有专门的图标
+        #   icon: "fa-brands fa-alipay" # 支付宝也有专门的图标
         #   qrcode: ""
         #   color: "#1677ff"
     
@@ -213,10 +213,10 @@ server:
     links:
       # - name: "GitHub"
       #   url: "https://github.com/xxx"
-      #   icon: "fab fa-github"       # 品牌图标使用 fab
+      #   icon: "fa-brands fa-github" # 品牌图标使用 fa-brands
       # - name: "文档"
       #   url: "https://docs.example.com"
-      #   icon: "fas fa-book"         # 通用图标使用 fas
+      #   icon: "fa-classic fa-solid fa-book" # 通用图标使用 fa-classic fa-solid
     
     # 免责声明配置
     disclaimer:

--- a/main.go
+++ b/main.go
@@ -26,7 +26,19 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const apiTokenEnv = "DMM_API_TOKEN"
+const (
+	apiTokenEnv = "DMM_API_TOKEN"
+	appName     = "docker-mirror-monitor"
+)
+
+var (
+	Version   = "dev"
+	BuildTime = "unknown"
+)
+
+func versionInfo() string {
+	return fmt.Sprintf("%s %s (built %s)", appName, Version, BuildTime)
+}
 
 // TagColor 标签颜色配置
 type TagColor struct {
@@ -1028,7 +1040,7 @@ func (c *Config) fillDefaultSiteNotice() {
 			c.Server.SiteNotice.BgColor = "rgba(255,107,107,0.1)"
 		}
 		if c.Server.SiteNotice.Icon == "" {
-			c.Server.SiteNotice.Icon = "fas fa-bullhorn"
+			c.Server.SiteNotice.Icon = "fa-classic fa-solid fa-bullhorn"
 		}
 	}
 }
@@ -1040,7 +1052,7 @@ func (c *Config) fillDefaultSite() {
 	}
 	if c.Server.Site.LogoIcon == "" {
 		// 修改默认值为完整的类名
-		c.Server.Site.LogoIcon = "fab fa-docker"
+		c.Server.Site.LogoIcon = "fa-brands fa-docker"
 	}
 	if c.Server.Site.Title == "" {
 		c.Server.Site.Title = "容器镜像加速器监控"
@@ -1088,7 +1100,7 @@ const htmlTemplate = `<!DOCTYPE html>
     <title>{{.Site.BrowserTitle}}</title>
     {{if .Site.Favicon}}<link rel="icon" href="{{.Site.Favicon}}" type="image/x-icon">{{end}}
     
-    <link rel="stylesheet" href="https://cdn.bootcdn.net/ajax/libs/font-awesome/5.15.4/css/all.min.css" onerror="loadFallbackCSS()">
+    <link rel="stylesheet" href="https://cdn.bootcdn.net/ajax/libs/font-awesome/7.3.1/css/all.min.css" integrity="sha384-qrALq7+6jBOZIQsNnT6xGkMDru64qD6uTlDra39xrt2SoXl4pO3FX6Roz/RpR/BS" crossorigin="anonymous" referrerpolicy="no-referrer" onerror="loadFallbackCSS()">
     
     <script>
         function loadFallbackCSS() {
@@ -1096,7 +1108,10 @@ const htmlTemplate = `<!DOCTYPE html>
             var link = document.createElement('link');
             link.rel = 'stylesheet';
             // 备用源：使用 cdnjs (Cloudflare)
-            link.href = 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css';
+            link.href = 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.3.1/css/all.min.css';
+            link.integrity = 'sha384-qrALq7+6jBOZIQsNnT6xGkMDru64qD6uTlDra39xrt2SoXl4pO3FX6Roz/RpR/BS';
+            link.crossOrigin = 'anonymous';
+            link.referrerPolicy = 'no-referrer';
             document.head.appendChild(link);
         }
     </script>
@@ -2232,9 +2247,9 @@ const htmlTemplate = `<!DOCTYPE html>
                     </div>
                     <div class="theme-selector">
 						<button type="button" class="theme-selector-btn" id="theme-selector-btn" title="选择主题" aria-expanded="false" aria-controls="theme-dropdown">
-                            <i class="fa fa-paint-brush"></i>
+                            <i class="fa-classic fa-solid fa-paint-brush"></i>
                             <span id="current-theme-name">紫蓝渐变</span>
-                            <i class="fa fa-angle-down"></i>
+                            <i class="fa-classic fa-solid fa-angle-down"></i>
                         </button>
                         <div class="theme-dropdown" id="theme-dropdown">
 							<button type="button" class="theme-option active" data-theme="default" aria-pressed="true">
@@ -2248,7 +2263,7 @@ const htmlTemplate = `<!DOCTYPE html>
 						</div>
 					</div>
 					<button type="button" id="theme-toggle" title="切换深色/浅色模式" aria-label="切换深色或浅色模式">
-                        <i class="fa fa-moon"></i>
+                        <i class="fa-classic fa-solid fa-moon"></i>
                     </button>
                 </div>
             </div>
@@ -2265,7 +2280,7 @@ const htmlTemplate = `<!DOCTYPE html>
 			<button type="button" class="tab-btn{{if eq $index 0}} active{{end}}" data-group="{{$group.ID}}">{{$group.Name}}</button>
             {{end}}
             {{if .About.Enabled}}
-			<button type="button" class="tab-btn" data-group="about"><i class="fa fa-info-circle"></i> {{if .About.Title}}{{.About.Title}}{{else}}关于{{end}}</button>
+			<button type="button" class="tab-btn" data-group="about"><i class="fa-classic fa-solid fa-info-circle"></i> {{if .About.Title}}{{.About.Title}}{{else}}关于{{end}}</button>
             {{end}}
         </nav>
 
@@ -2280,7 +2295,7 @@ const htmlTemplate = `<!DOCTYPE html>
                             <p class="stat-label">总监控站点</p>
                             <h3 class="stat-value stat-total">{{$group.Total}}</h3>
                         </div>
-                        <div class="stat-icon total"><i class="fa fa-sitemap"></i></div>
+                        <div class="stat-icon total"><i class="fa-classic fa-solid fa-sitemap"></i></div>
                     </div>
                 </div>
                 <div class="stat-card gradient-success">
@@ -2289,7 +2304,7 @@ const htmlTemplate = `<!DOCTYPE html>
                             <p class="stat-label">健康</p>
                             <h3 class="stat-value stat-healthy">{{$group.Healthy}}</h3>
                         </div>
-                        <div class="stat-icon online"><i class="fa fa-check-circle"></i></div>
+                        <div class="stat-icon online"><i class="fa-classic fa-solid fa-check-circle"></i></div>
                     </div>
                 </div>
                 <div class="stat-card gradient-warning">
@@ -2298,7 +2313,7 @@ const htmlTemplate = `<!DOCTYPE html>
                             <p class="stat-label">慢速</p>
                             <h3 class="stat-value stat-slow">{{$group.Slow}}</h3>
                         </div>
-                        <div class="stat-icon slow"><i class="fa fa-clock"></i></div>
+                        <div class="stat-icon slow"><i class="fa-classic fa-solid fa-clock"></i></div>
                     </div>
                 </div>
                 <div class="stat-card gradient-danger">
@@ -2307,7 +2322,7 @@ const htmlTemplate = `<!DOCTYPE html>
                             <p class="stat-label">异常</p>
                             <h3 class="stat-value stat-abnormal">{{$group.Abnormal}}</h3>
                         </div>
-                        <div class="stat-icon offline"><i class="fa fa-times-circle"></i></div>
+                        <div class="stat-icon offline"><i class="fa-classic fa-solid fa-times-circle"></i></div>
                     </div>
                 </div>
             </div>
@@ -2329,7 +2344,7 @@ const htmlTemplate = `<!DOCTYPE html>
                 <div class="mirror-selection-header">
                     <h4 class="mirror-selection-title">选择在线镜像源</h4>
                     <div class="mirror-selection-actions">
-						<button type="button" class="btn-sm btn-success use-recommended"><i class="fa fa-star"></i> 使用推荐配置</button>
+						<button type="button" class="btn-sm btn-success use-recommended"><i class="fa-classic fa-solid fa-star"></i> 使用推荐配置</button>
 						<button type="button" class="btn-sm btn-primary select-all-online">全选在线</button>
 						<button type="button" class="btn-sm btn-secondary clear-selection">清空选择</button>
                     </div>
@@ -2350,11 +2365,11 @@ const htmlTemplate = `<!DOCTYPE html>
 					</label>
                     {{end}}
                 </div>
-                <p class="mirror-hint"><i class="fa fa-info-circle"></i> 建议选择 3-5 个镜像源以保证稳定性</p>
+                <p class="mirror-hint"><i class="fa-classic fa-solid fa-info-circle"></i> 建议选择 3-5 个镜像源以保证稳定性</p>
 
                 <div class="config-output-header">
                     <h4 class="mirror-selection-title">生成的配置</h4>
-					<button type="button" class="btn-sm btn-success copy-config"><i class="fa fa-copy"></i> 复制配置</button>
+					<button type="button" class="btn-sm btn-success copy-config"><i class="fa-classic fa-solid fa-copy"></i> 复制配置</button>
                 </div>
                 <div class="code-block">
                     <pre><code class="config-output"></code></pre>
@@ -2421,7 +2436,7 @@ const htmlTemplate = `<!DOCTYPE html>
             <!-- 默认关于页面 -->
             <div class="about-section">
                 <div class="about-intro card">
-                    <h3 class="card-title"><i class="fa fa-info-circle"></i> 项目介绍</h3>
+                    <h3 class="card-title"><i class="fa-classic fa-solid fa-info-circle"></i> 项目介绍</h3>
                     <div class="about-description">
                         {{if .About.Description}}{{safeHTML .About.Description}}{{else}}
                         <p>容器镜像监控系统是一个开源项目，帮助开发者实时监控各种容器镜像加速器的可用性和响应速度。</p>
@@ -2431,7 +2446,7 @@ const htmlTemplate = `<!DOCTYPE html>
 
                 {{if .About.Donate.Enabled}}
                 <div class="about-donate card">
-                    <h3 class="card-title"><i class="fa fa-heart"></i> {{if .About.Donate.Title}}{{.About.Donate.Title}}{{else}}支持本项目{{end}}</h3>
+                    <h3 class="card-title"><i class="fa-classic fa-solid fa-heart"></i> {{if .About.Donate.Title}}{{.About.Donate.Title}}{{else}}支持本项目{{end}}</h3>
                     {{if .About.Donate.Description}}
                     <p class="donate-desc">{{.About.Donate.Description}}</p>
                     {{end}}
@@ -2440,7 +2455,7 @@ const htmlTemplate = `<!DOCTYPE html>
                         {{range .About.Donate.Items}}
                         <div class="donate-item" style="{{if .Color}}border-color: {{.Color}}{{end}}">
                             <div class="donate-header">
-                                <i class="{{if .Icon}}{{.Icon}}{{else}}fa-gift{{end}}" style="{{if .Color}}color: {{.Color}}{{end}}"></i>
+                                <i class="{{if .Icon}}{{.Icon}}{{else}}fa-classic fa-solid fa-gift{{end}}" style="{{if .Color}}color: {{.Color}}{{end}}"></i>
                                 <span>{{.Name}}</span>
                             </div>
                             {{if .QRCode}}
@@ -2458,7 +2473,7 @@ const htmlTemplate = `<!DOCTYPE html>
                 {{if .About.Partners.Enabled}}
                 {{if .About.Partners.Items}}
                 <div class="about-partners card">
-                    <h3 class="card-title"><i class="fa fa-bullhorn"></i> 推荐服务</h3>
+                    <h3 class="card-title"><i class="fa-classic fa-solid fa-bullhorn"></i> 推荐服务</h3>
                     <div class="partners-grid">
                         {{range .About.Partners.Items}}
                         <a href="{{.URL}}" target="_blank" rel="noopener" class="partner-item" style="{{if .Color}}border-color: {{.Color}}{{end}}">
@@ -2478,11 +2493,11 @@ const htmlTemplate = `<!DOCTYPE html>
 
                 {{if .About.Links}}
                 <div class="about-links card">
-                    <h3 class="card-title"><i class="fa fa-link"></i> 相关链接</h3>
+                    <h3 class="card-title"><i class="fa-classic fa-solid fa-link"></i> 相关链接</h3>
                     <div class="links-grid">
                         {{range .About.Links}}
                         <a href="{{.URL}}" target="_blank" rel="noopener" class="link-item">
-                            <i class="{{if .Icon}}{{.Icon}}{{else}}fa-external-link{{end}}"></i>
+                            <i class="{{if .Icon}}{{.Icon}}{{else}}fa-classic fa-solid fa-external-link{{end}}"></i>
                             <span>{{.Name}}</span>
                         </a>
                         {{end}}
@@ -2492,13 +2507,13 @@ const htmlTemplate = `<!DOCTYPE html>
 
                 {{if .About.Disclaimer.Enabled}}
                 <div class="about-disclaimer card">
-                    <h3 class="card-title"><i class="fa fa-exclamation-triangle"></i> {{if .About.Disclaimer.Title}}{{.About.Disclaimer.Title}}{{else}}免责声明{{end}}</h3>
+                    <h3 class="card-title"><i class="fa-classic fa-solid fa-exclamation-triangle"></i> {{if .About.Disclaimer.Title}}{{.About.Disclaimer.Title}}{{else}}免责声明{{end}}</h3>
                     <div class="disclaimer-content">
                         {{if .About.Disclaimer.Content}}{{safeHTML .About.Disclaimer.Content}}{{end}}
                     </div>
                     {{if .About.Disclaimer.AIGenerated}}
                     <div class="ai-generated-badge">
-                        <i class="fa fa-robot"></i> {{if .About.Disclaimer.AIStatement}}{{.About.Disclaimer.AIStatement}}{{else}}本项目由 AI 辅助生成{{end}}
+                        <i class="fa-classic fa-solid fa-robot"></i> {{if .About.Disclaimer.AIStatement}}{{.About.Disclaimer.AIStatement}}{{else}}本项目由 AI 辅助生成{{end}}
                     </div>
                     {{end}}
                 </div>
@@ -2538,7 +2553,7 @@ const htmlTemplate = `<!DOCTYPE html>
 			const toast = document.createElement('div');
 			toast.className = 'toast ' + type;
 			const icon = document.createElement('i');
-			icon.className = 'fa ' + (type === 'success' ? 'fa-check-circle' : 'fa-times-circle');
+			icon.className = 'fa-classic fa-solid ' + (type === 'success' ? 'fa-check-circle' : 'fa-times-circle');
 			const text = document.createElement('span');
 			text.textContent = message;
 			toast.append(icon, text);
@@ -2574,7 +2589,7 @@ const htmlTemplate = `<!DOCTYPE html>
         
         function setDarkMode(dark) {
             document.body.classList.toggle('dark', dark);
-            themeIcon.className = dark ? 'fa fa-sun' : 'fa fa-moon';
+            themeIcon.className = dark ? 'fa-classic fa-solid fa-sun' : 'fa-classic fa-solid fa-moon';
             localStorage.setItem('darkMode', dark ? 'dark' : 'light');
         }
         
@@ -3307,7 +3322,12 @@ func resolveConfigPath(configPath, configShort string) string {
 func main() {
 	configPath := flag.String("config", "config.yaml", "配置文件路径")
 	configShort := flag.String("c", "config.yaml", "配置文件路径")
+	showVersion := flag.Bool("version", false, "显示版本信息")
 	flag.Parse()
+	if *showVersion {
+		fmt.Println(versionInfo())
+		return
+	}
 
 	// 使用 -c 参数优先，如果没有指定 -c 则使用 --config
 	actualConfigPath := resolveConfigPath(*configPath, *configShort)
@@ -3315,6 +3335,10 @@ func main() {
 	// 检查是否有额外的命令行参数
 	args := flag.Args()
 	if len(args) > 0 {
+		if args[0] == "version" {
+			fmt.Println(versionInfo())
+			return
+		}
 		if args[0] == "healthcheck" {
 			// 设置默认值
 			listenAddr := ":9080"

--- a/main_test.go
+++ b/main_test.go
@@ -15,6 +15,59 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+func TestFontAwesomeAssetsArePinned(t *testing.T) {
+	const (
+		version   = "7.3.1"
+		integrity = "sha384-qrALq7+6jBOZIQsNnT6xGkMDru64qD6uTlDra39xrt2SoXl4pO3FX6Roz/RpR/BS"
+	)
+
+	for _, assetURL := range []string{
+		"https://cdn.bootcdn.net/ajax/libs/font-awesome/" + version + "/css/all.min.css",
+		"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/" + version + "/css/all.min.css",
+	} {
+		if !strings.Contains(htmlTemplate, assetURL) {
+			t.Errorf("html template is missing Font Awesome asset %q", assetURL)
+		}
+	}
+	if got := strings.Count(htmlTemplate, integrity); got != 2 {
+		t.Fatalf("Font Awesome integrity value appears %d times, want 2", got)
+	}
+	if strings.Contains(htmlTemplate, "font-awesome/5.") {
+		t.Fatal("html template still references Font Awesome 5")
+	}
+	if strings.Contains(htmlTemplate, `class="fa fa-`) || strings.Contains(htmlTemplate, "className = 'fa ") {
+		t.Fatal("html template still contains legacy built-in Font Awesome classes")
+	}
+}
+
+func TestDefaultIconClassesUseFontAwesomeSevenSyntax(t *testing.T) {
+	config := &Config{}
+	config.Server.SiteNotice.Enabled = true
+	config.fillDefaultSiteNotice()
+	config.fillDefaultSite()
+
+	if got, want := config.Server.SiteNotice.Icon, "fa-classic fa-solid fa-bullhorn"; got != want {
+		t.Fatalf("site notice icon = %q, want %q", got, want)
+	}
+	if got, want := config.Server.Site.LogoIcon, "fa-brands fa-docker"; got != want {
+		t.Fatalf("site logo icon = %q, want %q", got, want)
+	}
+}
+
+func TestVersionInfo(t *testing.T) {
+	originalVersion, originalBuildTime := Version, BuildTime
+	t.Cleanup(func() {
+		Version = originalVersion
+		BuildTime = originalBuildTime
+	})
+
+	Version = "v1.2.3"
+	BuildTime = "20260818094552"
+	if got, want := versionInfo(), "docker-mirror-monitor v1.2.3 (built 20260818094552)"; got != want {
+		t.Fatalf("versionInfo() = %q, want %q", got, want)
+	}
+}
+
 func TestReloadRequestAuthorization(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## Summary

- upgrade Font Awesome from 5.15.4 to 7.3.1 with matching SRI on the primary and fallback CDNs
- migrate built-in icon classes and configuration examples to Font Awesome 7 syntax while retaining upstream compatibility for existing legacy classes
- expose build version/time through `version` and `--version`, and propagate the metadata through Makefile and Docker builds
- correct CI/CD and version-tag examples in the README

## Verification

- `go test -race ./...`
- `go vet ./...`
- `go mod verify`
- `govulncheck v1.7.0 ./...`
- `actionlint .github/workflows/*.yml`
- Trivy 0.74.0 filesystem/config/secret scan: 0 findings
- Trivy 0.74.0 image scan: 0 Alpine and Go binary vulnerabilities
- `make build-all VERSION=v9.9.9 BUILD_TIME=20260818094552`
- Docker build and in-container health/page assertions
- verified both Font Awesome CDNs return identical CSS with the pinned SHA-384 integrity value and all referenced icon selectors
