### PR TITLE
ci: stop publishing floating image tags

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -112,8 +112,6 @@ jobs:
             latest=false
           tags: |
             type=semver,pattern=v{{version}}
-            type=semver,pattern=v{{major}}.{{minor}}
-            type=semver,pattern=v{{major}}
             type=raw,value=${{ inputs.version_tag }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.version_tag != '' }}
             type=raw,value=latest,enable=${{ github.event_name != 'workflow_dispatch' || inputs.make_latest }}
 


### PR DESCRIPTION
## Summary

- stop publishing the floating `v<major>.<minor>` image tag
- stop publishing the floating `v<major>` image tag
- keep exact release tags such as `v1.1.5` and `latest`

## Verification

- `actionlint .github/workflows/*.yml`
- `yq eval . .github/workflows/build-docker-image.yml`
- `git diff --check`